### PR TITLE
Fix issues outlined in #1

### DIFF
--- a/Cue/Ast.fs
+++ b/Cue/Ast.fs
@@ -207,7 +207,7 @@ type StructLit =
       Comments: OComments }
     interface IExpr with
         member this.Print(level: int) =
-            $"{{{join level (this.Elts |> Array.map (fun c -> c :> INode))}}}"
+            $"{{{join level (this.Elts |> Array.map (fun c -> c :> INode))}{sep(level - 1)}}}"
 
         member this.Comments = this.Comments
         member this.DeclNode = ()

--- a/CueFSharp.fsproj
+++ b/CueFSharp.fsproj
@@ -24,9 +24,10 @@
     <Compile Include="DotnetToCue/Util.fs" />
 
     <!--     Basic types -->
-    <Compile Include="DotnetToCue/Ast.fs" />
-    <Compile Include="DotnetToCue/IRegister.fs" /> 
-    <Compile Include="DotnetToCue/Reference.fs" />
+    <Compile Include="DotnetToCue/Ast.fs" /> 
+    <Compile Include="DotnetToCue/Reference.fs" /> 
+    <Compile Include="DotnetToCue/Config.fs" /> 
+    <Compile Include="DotnetToCue/IRegister.fs" />
     <Compile Include="DotnetToCue/Scalars.fs" />
     <Compile Include="DotnetToCue/Vectors.fs" />
 
@@ -39,7 +40,6 @@
 
     <Compile Include="DotnetToCue/Module.fs" />
 
-    <Compile Include="DotnetToCue/Config.fs" />
     <Compile Include="DotnetToCue/Register.fs" /> 
     <Compile Include="DotnetToCue/Assembly.fs" />
 

--- a/DotnetToCue/Ast.fs
+++ b/DotnetToCue/Ast.fs
@@ -113,7 +113,7 @@ type ImportDecl =
             | _ ->
                 "import ("
                 + (join level (this.Specs.Values |> Seq.cast |> Seq.map ToINode))
-                + ")"
+                + "\n)\n"
 
         member this.Comments = this.Comments
         member this.DeclNode = ()

--- a/DotnetToCue/Class.fs
+++ b/DotnetToCue/Class.fs
@@ -62,8 +62,8 @@ let Class (reg: IRegistry) (t: ContextualType) =
 
     let methodDecls =
         match reg.Config.Cue.IgnoreClassMethods with
-        | true -> Methods reg (filter t.Type) t.Context |> Array.map ToIDecl
-        | false -> [||]
+        | false -> Methods reg (filter t.Type) t.Context |> Array.map ToIDecl
+        | true -> [||]
 
     let classExpr = {
         StructLit.Elts =

--- a/DotnetToCue/Config.fs
+++ b/DotnetToCue/Config.fs
@@ -17,8 +17,9 @@ type CueModule()=
 
 type Cue() = 
     member val Module = CueModule() with get, set
-    member val IgnoreClassMethods = true with get, set
+    member val IgnoreClassMethods = false with get, set
     member val ReferenceTypesAsNullable = true with get, set
+    member val NullableFieldAsUnion = true with get, set
 
 type Write () = 
     member val RootModule = "" with get, set

--- a/DotnetToCue/Config.fs
+++ b/DotnetToCue/Config.fs
@@ -17,6 +17,8 @@ type CueModule()=
 
 type Cue() = 
     member val Module = CueModule() with get, set
+    member val IgnoreClassMethods = true with get, set
+    member val ReferenceTypesAsNullable = true with get, set
 
 type Write () = 
     member val RootModule = "" with get, set

--- a/DotnetToCue/Enum.fs
+++ b/DotnetToCue/Enum.fs
@@ -14,15 +14,21 @@ open Scalars
 let Enum (reg: IRegistry) (t: ContextualType) =
     // todo(ado): bases
     // todo(ado): check references updated correctly.
-    let cast o = cast o (t.Type.GetEnumUnderlyingType())
-
+    let stringValues = true
+    
+    let castx (f: FieldInfo) =
+        match stringValues with
+        | true -> cast f.Name typeof<string>
+        | false -> cast (f.GetRawConstantValue()) (t.Type.GetEnumUnderlyingType())
+                         
+    
     // todo this is black magic here.
     let literals =
         Array.filter (fun (f: FieldInfo) -> f.IsLiteral) (t.Type.GetFields())
 
     let fieldDecls =
         literals
-        |> Array.map (fun (f: FieldInfo) -> Field.New f.Name (cast (f.GetRawConstantValue())) :> IDecl)
+        |> Array.map (fun (f: FieldInfo) -> Field.New f.Name (castx f) :> IDecl)
 
     let enumMap =
         { StructLit.Elts = fieldDecls

--- a/DotnetToCue/Fields.fs
+++ b/DotnetToCue/Fields.fs
@@ -3,8 +3,28 @@ module CueFSharp.DotnetToCue.Fields
 open System.Reflection
 
 open CueFSharp.Cue.Ast
+open CueFSharp.DotnetToCue.Scalars
 open Ast
 open IRegister
+
+let FieldDecl (reg: IRegistry) (m: MemberInfo) (ctx: AbsoluteValueIdent) =
+    
+    let t =
+        match m with
+        | :? FieldInfo as fi ->  fi.FieldType
+        | :? PropertyInfo as pi -> pi.PropertyType
+        | _ -> failwith $"Unexpected MemberInfo: {m.GetType}"
+    
+    let f =
+        match reg.GetExprFromAttribute(m.CustomAttributes) with
+        | Some expr -> expr :> IExpr
+        | None -> reg.TypeContextual {
+              ContextualType.Type = unwrapNullable t
+              Context = ctx
+            }
+        |> Field.New m.Name
+
+    Some({ f with Optional = isNullable t })
 
 /// Field values are always referenced by label.
 /// todo(ado):
@@ -13,14 +33,8 @@ open IRegister
 /// - optional - i.e. not required to be present (as opposed to be present and null)
 /// todo - check that all pi.Name are valid cue idents. Should be the case.
 let Field (reg: IRegistry) (fi: FieldInfo) (ctx: AbsoluteValueIdent) =
-    if fi.IsPublic then
-
-        let n =
-            (reg.TypeContextual
-                { ContextualType.Type = fi.FieldType
-                  Context = ctx })
-
-        Some(Field.New fi.Name n)
+    if fi.IsPublic && not fi.IsStatic then
+        FieldDecl reg fi ctx
     else
         None
 
@@ -29,13 +43,10 @@ let Fields (reg: IRegistry) (fis: FieldInfo []) (ctx: AbsoluteValueIdent) =
 
 // todo - CanWrite properties?
 let Property (reg: IRegistry) (pi: PropertyInfo) (ctx: AbsoluteValueIdent) =
-    if pi.CanRead then
-        let n =
-            (reg.TypeContextual
-                { ContextualType.Type = pi.PropertyType
-                  Context = ctx })
-
-        Some(CueFSharp.Cue.Ast.Field.New pi.Name n)
+    let isStatic = pi.GetAccessors() |> Seq.tryFind(fun m -> m.IsStatic) |> Option.isSome
+    
+    if pi.CanRead && not isStatic then
+        FieldDecl reg pi ctx
     else
         None
 

--- a/DotnetToCue/IRegister.fs
+++ b/DotnetToCue/IRegister.fs
@@ -24,8 +24,9 @@ type ContextualType =
 
 type IRegistry =
    abstract member Config: Config.Config
-   abstract member GetExprFromAttribute: Generic.IEnumerable<CustomAttributeData> -> Option<Ident>
+   abstract member GetExprFromAlias: MemberInfo -> Option<IExpr>
    abstract member TypeContextual: ContextualType -> IExpr
    abstract member Type: Type -> IExpr
    abstract member AddReference: string -> AbsoluteValueIdent -> unit
    abstract member AddExpr: AbsoluteValueIdent -> IExpr -> unit
+   abstract member AddTypeAlias: string -> string -> unit

--- a/DotnetToCue/IRegister.fs
+++ b/DotnetToCue/IRegister.fs
@@ -1,7 +1,10 @@
 module CueFSharp.DotnetToCue.IRegister
 
 open System
+open System.Collections
+open System.Reflection
 open CueFSharp.Cue.Ast
+open CueFSharp.DotnetToCue
 open Ast
 
 // For composite literals, there is no path to return. 
@@ -19,7 +22,9 @@ type ContextualType =
         Context: AbsoluteValueIdent
     }
 
-type IRegistry = 
+type IRegistry =
+   abstract member Config: Config.Config
+   abstract member GetExprFromAttribute: Generic.IEnumerable<CustomAttributeData> -> Option<Ident>
    abstract member TypeContextual: ContextualType -> IExpr
    abstract member Type: Type -> IExpr
    abstract member AddReference: string -> AbsoluteValueIdent -> unit

--- a/DotnetToCue/Reference.fs
+++ b/DotnetToCue/Reference.fs
@@ -55,7 +55,7 @@ let tryReference (d: (Assembly -> string)) (t: Type) =
 
 
         let selectors =
-            let e = t.FullName.[t.Namespace.Length + 1..]
+            let e = t.FullName.[t.Namespace.Length + 1..].Replace("[]", "Array") // Hacky fix for C# Array types
 
             match e.Length with
             | 0 -> Some(Array.empty)

--- a/DotnetToCue/Register.fs
+++ b/DotnetToCue/Register.fs
@@ -18,7 +18,7 @@ open Scalars
 open Module
 open Config
 
-type CueExpression (expr: Object) =
+type CueExpressionAttribute (expr: Object) =
     inherit System.Attribute()
     member this.Expr = cast(expr)(expr.GetType())
 
@@ -112,10 +112,10 @@ type Registry =
         file.Decls.Add(ref.ToLocalExpr expr)
         
     member r.GetExprFromAlias(m: MemberInfo) =
-        let name = typeof<CueExpression>.FullName
+        let name = typeof<CueExpressionAttribute>.Name
         
         m.GetCustomAttributesData()
-        |> Seq.tryFind(fun attr -> attr.AttributeType.FullName = name)
+        |> Seq.tryFind(fun attr -> attr.AttributeType.Name = name)
         |> function
             | Some a ->
                 match Seq.tryHead a.ConstructorArguments with

--- a/DotnetToCue/Scalars.fs
+++ b/DotnetToCue/Scalars.fs
@@ -16,11 +16,12 @@ let isNullable (t: Type) =
     | _ ->
         match t.GenericTypeArguments with
         | null -> false
-        | _ -> not t.IsGenericTypeDefinition && t.GenericTypeArguments.Length > 0 && t.Name.Contains("Nullable")
+        | _ -> not (t.IsGenericTypeDefinition && t.GenericTypeArguments.Length > 0 && t.Name.Contains("Nullable"))
+               && not (t.CustomAttributes |> Seq.tryFind(fun a -> a.AttributeType.FullName.Contains("System.Runtime.CompilerServices.Nullable")) |> Option.isSome)
     
 let unwrapNullable (t: Type) =
     match isNullable t with
-    | true -> t.GenericTypeArguments.[0]
+    | true -> t.GenericTypeArguments |> Seq.tryHead |> Option.defaultValue t
     | false -> t
 
 type Literal =
@@ -42,7 +43,7 @@ let literal value =
 let Kinds =
     Map(
         [ "System.Boolean", Ident.New "bool" :> IExpr
-          "System.Double", Ident.New "float" :> IExpr
+          "System.Double", Ident.New "number" :> IExpr
           "System.Int32", Ident.New "int32" :> IExpr
           "System.String", Ident.New "string"  :> IExpr
           "System.Void", BasicLit.NewNull() :> IExpr]

--- a/DotnetToCue/Scalars.fs
+++ b/DotnetToCue/Scalars.fs
@@ -10,6 +10,18 @@ let isPrimitive (t: Type) =
     t.IsPrimitive
     || Array.contains t.FullName [| "System.String"; "System.Void"|]
 
+let isNullable (t: Type) =
+    match t with
+    | null -> false
+    | _ ->
+        match t.GenericTypeArguments with
+        | null -> false
+        | _ -> not t.IsGenericTypeDefinition && t.GenericTypeArguments.Length > 0 && t.Name.Contains("Nullable")
+    
+let unwrapNullable (t: Type) =
+    match isNullable t with
+    | true -> t.GenericTypeArguments.[0]
+    | false -> t
 
 type Literal =
     | Bool of bool

--- a/DotnetToCue/Type.fs
+++ b/DotnetToCue/Type.fs
@@ -24,7 +24,7 @@ let NewExpr (reg: IRegistry) (t: ContextualType)  =
             // https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/reference-types
             // do any other reference types need consideration?
             if t.Type.IsClass then
-                Class.Class reg t :> IExpr 
+                Class.Class reg t
             elif t.Type.IsValueType then
                 // https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/value-types
                 if isEnum t.Type then


### PR DESCRIPTION
# Details
I've put together this PR to address the changes I outlined in #1, this is my first time using F# so let me know if I'm doing some things wrong.

# Changes

### Cue Config
- `IgnoreClassMethods` skips outputting class methods as field declarations
- `ReferenceTypesAsNullable` skips wrapping reference types with `null` union

### Field/Property support Nullable<'T>
- Unwraps nullable types and outputs an optional field, `public int? Steps` -> `Steps?: int32`

### `CueExpression` Attribute
Overrides the field declaration output with the provided string:
```csharp
[CueExpression(@"""Slash1H"" | ""Pierce1H"" | ""Bash1H""")]
public WeaponAnimation Animation { get; set; }
```
->
```cue
Animation: "Slash1H" | "Pierce1H" | "Bash1H"
```

Can also be applied to classes:
```csharp
[CueExpression(@"""First"" | ""Second""")]
public enum TestEnum
{
    First,
    Second
}
public class TestCueType
{
    public TestEnum Value { get; set; }
}
```
->
```cue
#TestEnum: "First" | "Second"
```


### Extra whitespace around structs/imports  
```cue
package Monsters
import (
    Items "github.com/zuluhotelaustralia/zuluhotel/Server/Items")
#TestCueType: {
    @dotnet({FullName:Server.Mobiles.Monsters.TestCueType})
    Animation?: Items.#WeaponAnimation
    Steps?: int32}
```
->
```cue
package Monsters
import (
    Items "github.com/zuluhotelaustralia/zuluhotel/Server/Items"
)

#TestCueType: {
    @dotnet({FullName:Server.Mobiles.Monsters.TestCueType})
    Animation?: Items.#WeaponAnimation
    Steps?: int32
}
```